### PR TITLE
fix bug 'finished' always being false

### DIFF
--- a/src/animation.js
+++ b/src/animation.js
@@ -129,7 +129,7 @@ var Animation = function () {
             nextRenderTime += frame.delay;
         } else {
             played = false;
-            finished = false;
+            finished = true;
         }
     };
 };


### PR DESCRIPTION
When finished animating, set variant "finish" true.
